### PR TITLE
Update applyPolicy function in apply_policies.go to enforce cluster-wide mode by default

### DIFF
--- a/pkg/tools/apply_policies.go
+++ b/pkg/tools/apply_policies.go
@@ -74,12 +74,9 @@ func applyPolicy(policyKey string, namespace string, gitBranch string, namespace
 		return "", fmt.Errorf("failed to close temp policy file: %w", err)
 	}
 
-	// Determine if we should run cluster-wide (no namespace specified) or namespace-scoped.
-	clusterMode := strings.TrimSpace(namespace) == ""
-
 	applyCommandConfig := &apply.ApplyCommandConfig{
 		PolicyPaths:  []string{tmpFile.Name()},
-		Cluster:      clusterMode,
+		Cluster:      true,
 		Namespace:    namespace,
 		PolicyReport: true,
 		OutputFormat: "json",


### PR DESCRIPTION
- Changed the Cluster field in ApplyCommandConfig to always be true, simplifying the logic for applying policies without namespace specification.