### PR TITLE
Show-violations-tool-fix

### DIFF
--- a/pkg/tools/show_violations.go
+++ b/pkg/tools/show_violations.go
@@ -156,7 +156,6 @@ func gatherViolationsJSON(ctx context.Context, ns, nsExclude string) ([]byte, er
 					continue
 				}
 
-
 				allResults = append(allResults, result)
 			}
 		}


### PR DESCRIPTION
- Renamed helper function to addPolicyReportResults for clarity.
- Enhanced filtering logic to include warnings in the criteria for skipping reports.
- Introduced a new helper function addClusterPolicyReportResults to handle ClusterPolicyReport items, ensuring consistent processing of results.
- Improved code readability and maintainability by separating concerns for PolicyReport and ClusterPolicyReport handling.